### PR TITLE
fix cql2-text example styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ This example uses the queryables definition in (Interaction with Endpoints)(#int
 Note that `filter-lang` defaults to `cql2-text` in this case. The parameter `filter-crs` defaults
 to `http://www.opengis.net/def/crs/OGC/1.3/CRS84` for a STAC API.
 
-```http
+```
 filter=id='LC08_L1TP_060247_20180905_20180912_01_T1_L1TP' AND collection='landsat8_l1tp'
 ```
 
@@ -520,7 +520,7 @@ OGC API Features filters only operate against a single collection already.
 
 #### Example 2: GET with cql2-text
 
-```http
+```
 filter=collection = 'landsat8_l1tp'
   AND eo:cloud_cover <= 10
   AND datetime >= TIMESTAMP('2021-04-08T04:39:23Z')
@@ -672,7 +672,7 @@ a tiny sliver of data.
 
 #### Example 3: AND cql2-text (GET)
 
-```http
+```
 filter=sentinel:data_coverage > 50 AND eo:cloud_cover < 10
 ```
 
@@ -706,7 +706,7 @@ This uses the same queryables as Example 4.
 
 #### Example 4: OR cql2-text (GET)
 
-```http
+```
 filter=sentinel:data_coverage > 50 OR eo:cloud_cover < 10
 ```
 
@@ -762,7 +762,7 @@ This queryables JSON Schema is used in these examples:
 
 #### Example 5: GET with cql2-text
 
-```http
+```
 filter=prop1 = prop2
 ```
 
@@ -790,7 +790,7 @@ have any overlap between them.
 
 #### Example 6: T_INTERSECTS cql2-text (GET)
 
-```http
+```
 filter=datetime T_INTERSECTS INTERVAL('2020-11-11T00:00:00Z', '2020-11-12T00:00:00Z')
 ```
 
@@ -818,7 +818,7 @@ format uses GeoJSON geometries.
 
 #### Example 7: S_INTERSECTS cql2-text (GET)
 
-```http
+```
 filter=S_INTERSECTS(geometry,POLYGON((-77.0824 38.7886,-77.0189 38.7886,-77.0189 38.8351,-77.0824 38.8351,-77.0824 38.7886)))
 ```
 
@@ -853,7 +853,7 @@ logical operator.
 
 #### Example 8: S_INTERSECTS cql2-text (GET)
 
-```http
+```
 filter=S_INTERSECTS(geometry,POLYGON((-77.0824 38.7886,-77.0189 38.7886,-77.0189 38.8351,-77.0824 38.8351,-77.0824 38.7886))) OR S_INTERSECTS(geometry,POLYGON((-79.0935 38.7886,-79.0290 38.7886,-79.0290 38.8351,-79.0935 38.8351,-79.0935 38.7886)))
 ```
 
@@ -909,7 +909,7 @@ either of those properties.
 
 #### Example 9: cql2-text (GET)
 
-```http
+```
 filter=sentinel:data_coverage > 50 OR landsat:coverage_percent < 10 OR (sentinel:data_coverage IS NULL AND landsat:coverage_percent IS NULL)
 ```
 
@@ -953,7 +953,7 @@ The BETWEEN operator allows for checking if a numeric value is within a specifie
 
 #### Example 10: cql2-text (GET)
 
-```http
+```
 filter=eo:cloud_cover BETWEEN 0 AND 50
 ```
 
@@ -978,7 +978,7 @@ The LIKE operator allows for pattern-based string matching.
 
 #### Example 11: cql2-text (GET)
 
-```http
+```
 filter=mission LIKE 'sentinel%'
 ```
 
@@ -1008,11 +1008,11 @@ insensitive representation whereby the expressions `CASEI('Straße')`, `CASEI('s
 
 #### Example 12: cql2-text (GET)
 
-```http
+```
 filter=CASEI(provider) = CASEI('coolsat')
 ```
 
-```http
+```
 filter=CASEI(provider) = CASEI('Straße')
 ```
 
@@ -1064,7 +1064,7 @@ defined in the Accent and Case-insensitive Comparison conformance class. In the 
 
 #### Example 13: cql2-text (GET)
 
-```http
+```
 filter=ACCENTI(provider) = ACCENTI('tiburón')
 ```
 


### PR DESCRIPTION
**Related Issue(s):** 

- #2 

**Proposed Changes:**

1. fix styling of CQL2-Text examples 

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
