### PR TITLE
Fix incorrect reference of operationId in collection specific links

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -63,7 +63,7 @@ paths:
           description: Collection description
           links:
             queryables:
-              operationId: getQueryables
+              operationId: getQueryablesForCollection
               description: |-
                 A link with rel=queryables for queryables to only apply to this collection.
   /collections/{collectionId}/queryables:


### PR DESCRIPTION
**Related Issue(s):** 

- None

**Proposed Changes:**

1. fix an incorrect reference of the operationId in the collection specific links section
https://swagger.io/docs/specification/paths-and-operations/

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/stac-api-extensions/filter/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
