### PR TITLE
References DotNetStac.Api for CQL2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic Spatial Operators in CQL2 now only requires BBOX and POINT support, so the text
   and examples were updated to account for this.
 
+### Added
+
+- References [DotNetStac.Api](https://github.com/Terradue/DotNetStac.Api) for its support
+    for [CQL2 JSON](https://github.com/Terradue/DotNetStac.Api/blob/5e7334e95da92ca19f9e9b75c476f362ae24a6da/src/Stac.Api/Models/Cql2/CQL2.cs)
+
 ## [v1.0.0-rc.2] - 2022-11-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ These projects have or are developing CQL2 support:
   including the ability to convert from CQL2 Text to CQL2 JSON
 - [xtraplatform-spatial](https://github.com/interactive-instruments/xtraplatform-spatial) has support for CQL2 Text and provides an [ANTLR 4 grammer](https://github.com/interactive-instruments/xtraplatform-spatial/tree/master/xtraplatform-cql/src/main/antlr/de/ii/xtraplatform/cql/infra)
 - [Geotools](https://github.com/geotools/geotools) has support for [CQL2 text](https://github.com/geotools/geotools/tree/main/modules/library/cql/src/main/java/org/geotools/filter/text/cql2)
+- [DotNetStac.Api](https://github.com/Terradue/DotNetStac.Api) has support for [CQL2 JSON](https://github.com/Terradue/DotNetStac.Api/blob/5e7334e95da92ca19f9e9b75c476f362ae24a6da/src/Stac.Api/Models/Cql2/CQL2.cs)
+  and implements [Linq extensions](https://github.com/Terradue/DotNetStac.Api/blob/6916507eaf21554872f5c03102d6c144e565e8f5/src/Stac.Api/Models/Cql2/Cql2Linq.cs)
+  to build [expressions trees](https://learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/expression-trees) from CQL2.
+  It also includes a [default query provider](https://github.com/Terradue/DotNetStac.Api/blob/ea93d783e024e7a8e64dacf06ccb62b94779bd2d/src/Stac.Api/Services/Queryable/StacQueryProvider.cs)
+  for STAC object enumerables implemented in [DotNetStac](https://github.com/Terradue/DotNetStac).
 
 Note that the xbib CQL library (JVM) is the OASIS Contextual Query Language, not
 OGC CQL, and should not be used to implement this extension, as they are significantly different query languages.


### PR DESCRIPTION
**Proposed Changes:**

1.  References [DotNetStac.Api](https://github.com/Terradue/DotNetStac.Api) for its support for [CQL2 JSON](https://github.com/Terradue/DotNetStac.Api/blob/5e7334e95da92ca19f9e9b75c476f362ae24a6da/src/Stac.Api/Models/Cql2/CQL2.cs)

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-api-extensions/filter/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
