### PR TITLE
Fixed the CQL2 JSON between operator example to use 3 items array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Basic Spatial Operators in CQL2 now only requires BBOX and POINT support, so the text
   and examples were updated to account for this.
+- Fixed the CQL2 JSON between operator example to use 3 items array
 
 ## [v1.0.0-rc.2] - 2022-11-01
 

--- a/README.md
+++ b/README.md
@@ -1018,7 +1018,7 @@ filter=eo:cloud_cover BETWEEN 0 AND 50
     "op": "between",
     "args": [
       { "property": "eo:cloud_cover" },
-      [ 0, 50 ]
+      0, 50
     ]
   }
 }


### PR DESCRIPTION
**Related Issue(s):** 

- #18

**Proposed Changes:**

1. Fixed the CQL2 JSON between operator example to use 3 items array

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-api-extensions/filter/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
