### PR TITLE
Remove recommendation to use fully-qualified property names as queryables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+
+### Changed
+
+- Remove recommendation to use fully-qualified property names as queryables.
+
 ## [v1.0.0-rc.3] - 2023-10-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@
     - [Example 14: Using the ACCENTI Accent-insensitive Comparison Function](#example-14-using-the-accenti-accent-insensitive-comparison-function)
       - [Example 14: cql2-text (GET)](#example-14-cql2-text-get)
       - [Example 14: cql2-json (POST)](#example-14-cql2-json-post)
+    - [Example 15: Using the IN List predicate](#example-15-using-the-in-list-predicate)
+      - [Example 15: cql2-text (GET)](#example-15-cql2-text-get)
+      - [Example 15: cql2-json (POST)](#example-15-cql2-json-post)
 
 ## Overview
 
@@ -278,7 +281,7 @@ returned according to OAFeat Part 3. It is recognized that this is a severe rest
 and dynamic content, so this behavior may be modified by setting the `additionalProperties` attribute in the
 queryables definition to `true`.  As such, any syntactically-valid term for a property will be accepted, and the
 matching semantics are such that, if an Item does not have an attribute by that name, the value is assumed to be
-`null`.  It is recommended to use fully-qualified property names (e.g., `properties.eo:cloud_cover`).
+`null`.
 
 Queryables are advertised via a JSON Schema document retrieved from the `/queryables` endpoint. This endpoint at the root
 retrieves queryables that apply to all collections. When used as a subresource of the collection resource


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/stac-api-extensions/filter/issues/29

**Proposed Changes:**

1. Remove recommendation to use fully-qualified property names as queryables. I'm not sure why the spec ever said that, because in practice just the field names used in the properties are set as the queryables terms.

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-api-extensions/filter/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
